### PR TITLE
Add doctl host wrapper binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ flatpak install app.freelens.Freelens
 The application is sandboxed. It brings bundled `kubectl` and `helm` commands
 and uses `~/.kube/config` file by default.
 
-Flatpak adds wrapper for `aws`, `gke-gcloud-auth-plugin` and `kubelogin`
-tools and runs them as a command from host system.
+Flatpak adds wrapper for `aws`, `doctl`, `gke-gcloud-auth-plugin` and
+`kubelogin` tools and runs them as a command from host system.
 
 Terminal uses `/bin/sh` by default but it might be switched either to ie.
 `/bin/bash` for sandboxed environment or `/app/bin/host-spawn` for host

--- a/app.freelens.Freelens.yaml
+++ b/app.freelens.Freelens.yaml
@@ -44,7 +44,7 @@ modules:
       - mv opt/Freelens "${FLATPAK_DEST}/Freelens"
       - install -Dm0755 freelens-launch.sh "${FLATPAK_DEST}/bin/freelens"
       - |
-        for cmd in assume aws gke-gcloud-auth-plugin kubelogin; do
+        for cmd in assume aws doctl gke-gcloud-auth-plugin kubelogin; do
           install -Dm0755 host-spawn.sh "${FLATPAK_DEST}/bin/$cmd"
         done
       - install -Dm0644 usr/share/applications/freelens.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"


### PR DESCRIPTION
For managed Kubernetes clusters on DigitalOcean, the DigitalOcean CLI utility `doctl` provides an cluster authentication mechanism.

For this to work in Freelens, a host wrapper is needed, just like for `aws`.

Given an authenticated CLI session and a managed Kubernetes cluster on DigitalOcean the kubeconfig can be populated by running `doctl kubernetes cluster kubeconfig save <cluster-uuid>`.

That will result in something like the following in `~/.kube/config`:
```yaml
users:
- name: <cluster-name>
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - kubernetes
      - cluster
      - kubeconfig
      - exec-credential
      - --version=v1beta1
      - --context=default
      - <cluster-uuid>
      command: doctl
      env: null
      interactiveMode: IfAvailable
      provideClusterInfo: false
```

This PR just adds the `doctl` binary to the list of host binaries that are wrapped. Note that I did not test this by building a local flatpak build.