### PR TITLE
Add scw wrapper for scaleway clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Note specific to Flatpak:
 The application is sandboxed. It includes bundled `kubectl` and `helm`
 commands and uses the `~/.kube/config` file by default.
 
-Flatpak adds wrappers for the `aws`, `doctl`, `gke-gcloud-auth-plugin`, and
-`kubelogin` tools, running them as commands from the host system.
+Flatpak adds wrappers for the `aws`, `doctl`, `gke-gcloud-auth-plugin`,
+`kubelogin` and `scw` tools, running them as commands from the host system.
 
 The terminal uses `/bin/sh` by default, but it can be switched to, for
 example, `/bin/bash` for a sandboxed environment or `/app/bin/host-spawn` for

--- a/app.freelens.Freelens.yaml
+++ b/app.freelens.Freelens.yaml
@@ -46,7 +46,7 @@ modules:
       - mv opt/Freelens "${FLATPAK_DEST}/Freelens"
       - install -Dm0755 freelens-launch.sh "${FLATPAK_DEST}/bin/freelens"
       - |
-        for cmd in assume aws doctl gke-gcloud-auth-plugin kubelogin; do
+        for cmd in assume aws doctl gke-gcloud-auth-plugin kubelogin scw; do
           install -Dm0755 host-spawn.sh "${FLATPAK_DEST}/bin/$cmd"
         done
       - install -Dm0644 usr/share/applications/freelens.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"


### PR DESCRIPTION
See https://github.com/flathub/app.freelens.Freelens/pull/3 for prior art

For managed Kubernetes clusters on [Scaleway](https://www.scaleway.com/en/) authentication is done via a vendor-specific CLI `scw`, just like for Google, AWS and DigitalOcean.

The relevant snippet of the `kubeconfig`, which can be obtained via `scw k8s kubeconfig get <cluster-id>`, is:
```yaml
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - k8s
      - exec-credential
      command: scw
      env: null
      installHint: |-
        This kubeconfig profile require scaleway-cli (scw) to authenticate.
        Installation instruction: https://github.com/scaleway/scaleway-cli#installation
      interactiveMode: Never
      provideClusterInfo: false
```

So let's add a host wrapper just like for the other vendors.