### PR TITLE
Add glab host-spawn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Note specific to Flatpak:
 The application is sandboxed. It includes bundled `kubectl` and `helm`
 commands and uses the `~/.kube/config` file by default.
 
-Flatpak adds wrappers for the `aws`, `doctl`, `gke-gcloud-auth-plugin`, and
-`kubelogin` tools, running them as commands from the host system.
+Flatpak adds wrappers for the `aws`, `doctl`, `gke-gcloud-auth-plugin`, `glab`, 
+and `kubelogin` tools, running them as commands from the host system.
 
 The terminal uses `/bin/sh` by default, but it can be switched to, for
 example, `/bin/bash` for a sandboxed environment or `/app/bin/host-spawn` for

--- a/app.freelens.Freelens.metainfo.xml
+++ b/app.freelens.Freelens.metainfo.xml
@@ -23,7 +23,7 @@
     <p>Freelens is maintained by the community.</p>
     <p>Note specific to Flatpak:</p>
     <p>The application is sandboxed. It includes bundled <code>kubectl</code> and <code>helm</code> commands and uses <code>~/.kube/config</code> file by default.</p>
-    <p>Flatpak adds wrapper for the <code>aws</code>, <code>doctl</code>, <code>gke-gcloud-auth-plugin</code> and <code>kubelogin</code> tools and runs them as a commands from the host system.</p>
+    <p>Flatpak adds wrapper for the <code>aws</code>, <code>doctl</code>, <code>gke-gcloud-auth-plugin</code>, <code>glab</code> and <code>kubelogin</code> tools and runs them as a commands from the host system.</p>
     <p>The terminal uses <code>/bin/sh</code> by default, but it can be switched to, for example, <code>/bin/bash</code> for sandboxed environment or <code>/app/bin/host-spawn</code> for a host environment.</p>
     <p>You can use <code>flatpak-override</code> to give access to the filesystem f.e. if you're missing <code>.minikube</code> certificates. <code>flatpak override --user --filesystem=~/.minikube app.freelens.Freelens</code>.</p>
   </description>

--- a/app.freelens.Freelens.yaml
+++ b/app.freelens.Freelens.yaml
@@ -46,7 +46,7 @@ modules:
       - mv opt/Freelens "${FLATPAK_DEST}/Freelens"
       - install -Dm0755 freelens-launch.sh "${FLATPAK_DEST}/bin/freelens"
       - |
-        for cmd in assume aws doctl gke-gcloud-auth-plugin kubelogin; do
+        for cmd in assume aws doctl gke-gcloud-auth-plugin glab kubelogin; do
           install -Dm0755 host-spawn.sh "${FLATPAK_DEST}/bin/$cmd"
         done
       - install -Dm0644 usr/share/applications/freelens.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"


### PR DESCRIPTION
Since GitLab provides a way to access Kubernetes Clusters, including authentication, locally managed through the `glab` binary, I think it makes sense to include a `host-spawn` link for it too.

It's the same as already done with `aws`, `doctl` etc. 

The user still needs to get their `glab`s config into the flatpak (`~/.config/glab-cli/config.yml`). I did not include granting the flatpak access to it as for the AWS credentials (as an example) it's was also not done.